### PR TITLE
some suggestions about how to forward requests based on the scene

### DIFF
--- a/proxy/src/main.cpp
+++ b/proxy/src/main.cpp
@@ -1,7 +1,7 @@
-#include "prime_server.hpp"
-#include "http_protocol.hpp"
+#include <prime_server/prime_server.hpp>
+#include <prime_server/http_protocol.hpp>
 using namespace prime_server;
-#include "logging.hpp"
+#include <prime_server/logging.hpp>
 
 int main(int argc, char** argv) {
     if(argc < 3) {

--- a/proxy/src/main.cpp
+++ b/proxy/src/main.cpp
@@ -21,18 +21,26 @@ int main(int argc, char** argv) {
     zmq::context_t context;
     proxy_t proxy(context, upstream_endpoint, downstream_endpoint, 
         [](const std::list<zmq::message_t>& heart_beats, const std::list<zmq::message_t>& job) -> const zmq::message_t* {
+            //parse the scene out
+            auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
+            auto scene_itr = request.query.find("scene");
+            std::string job_type;
+            //its a POST of a custom style, we'll assume the size of the thing is unique enough
+            if(scene_itr == request.query.cend())
+              job_type = std::to_string(request.body.size());
+            //its in the request params
+            else
+              job_type = scene_itr->second.front();
             //have a look at each heartbeat
             for(const auto& heart_beat : heart_beats) {
-                //so the heartbeat is a single char either A or B
-                const auto& beat_type = static_cast<const char*>(heart_beat.data())[0];
-                //but the job is in netstring format, so either 1:A, or 1:B,
-                const auto& job_type = static_cast<const char*>(job.front().data())[2];
-                //do we like this heartbeat
-                if(beat_type == job_type)
-                return &heart_beat;
+                //the heartbeat is the scene
+                std::string beat_type(static_cast<const char*>(heart_beat.data()));
+                //did this worker work on the same scene as this job
+                if(beat_type == *job_type)
+                    return &heart_beat;
             }
             //all of the heartbeats sucked so pick whichever
-          return nullptr;
+            return nullptr;
         }
     );
 

--- a/proxy/src/main.cpp
+++ b/proxy/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
             auto scene_itr = request.query.find("scene");
             std::string job_type;
             //its a POST of a custom style, we'll assume the size of the thing is unique enough
-            if(scene_itr == request.query.cend())
+            if(scene_itr == request.query.cend() || scene_itr->second.size() == 0)
               job_type = std::to_string(request.body.size());
             //its in the request params
             else

--- a/worker/src/paparazzi.cpp
+++ b/worker/src/paparazzi.cpp
@@ -283,10 +283,13 @@ worker_t::result_t Paparazzi::work (const std::list<zmq::message_t>& job, void* 
 
                 // ... other whise load content
                 setSceneContent(request.body);
+                // The size of the custom scene is unique enough
+                result.heart_beat = std::to_string(request.body.size());
             }
             else {
                 // If there IS a SCENE QUERRY value load it
                 setScene(scene_itr->second.front());
+                result.heart_beat = scene_itr->second.front();
             }
 
 
@@ -414,7 +417,6 @@ worker_t::result_t Paparazzi::work (const std::list<zmq::message_t>& job, void* 
     response.from_info(info);
 
     //formats the response to protocal that the client will understand
-    result.heart_beat = m_scene;
     result.messages.emplace_back(response.to_string());
     return result;
 }


### PR DESCRIPTION
i wanted to help out a bit with the bits about matching up the scene a worker just worked on and an incoming request. i decided not to do the md5 of the body for the custom scenes and just match them by the number of bytes figuring that was unique enough. if somehow they are different scenes but same size then oh well, the worker might have to do a job that wasnt optimized for it (seems like a rare case).
